### PR TITLE
WSGI middleware to inject analytics.js in <head/>

### DIFF
--- a/analytics/middlewares.py
+++ b/analytics/middlewares.py
@@ -75,13 +75,17 @@ class AnalyticsJSInjector(ContentModifier):
     def response_modifier(self, app_iter):
         """Should be implemented by descendants"""
         snippet_injected = False
+        html_detected = False
         for line in app_iter:
             if not snippet_injected:
-                if 'var analytics=analytics||[];analytics.load=function(e)' in line.lower():
+                if 'html>' in line.lower():
+                    html_detected = True
+
+                if html_detected and 'var analytics=analytics||[];analytics.load=function(e)' in line.lower():
                     # Detected already existing snippet. Stop trying to inject another.
                     snippet_injected = True
 
-                elif '<head>' in line.lower(): # Add to HEAD start
+                elif html_detected and '<head>' in line.lower(): # Add to HEAD start
                     line = line.replace('<HEAD>', '<head>').replace('<Head>', '<head>') # Clean the tag, if needed
                     line = line.replace('<head>', '<head>' + self.js_snippet)
                     snippet_injected = True


### PR DESCRIPTION
Hi.

I implemented a WSGI middleware to inject analytics.js snippet. It is implemented in a non-buffered fashion, so will not delay/swallow the stream, if yielded as chunks.

Before adding a new script, it searches `<head/>` for existing script. If found, it does not inject again. If not found, injects the snippet to `<head/>`. If `<head>` is on same chunk of `</head>` (or the response is not chunked), it injects right after the start of `<head>`.

If closing `</head>` is not on the same chunk as `<head>`, it injects right before `</head>`. Is this recommended/acceptable?

I could buffer `<head>` to `</head>` to be sure, but it delays the stream.
I could simple inject right after `<head>` start, but than I need to keep searching the next chunks for existing snippet, and then chop it if found.

Can I expect it to be merged? Have the original authors some consideration?
