### PR TITLE
Added json serialisation for datetimes

### DIFF
--- a/analytics/client.py
+++ b/analytics/client.py
@@ -10,7 +10,7 @@ import requests
 
 from stats import Statistics
 from errors import ApiError
-from utils import guess_timezone
+from utils import guess_timezone, DatetimeSerializer
 
 import options
 
@@ -66,7 +66,7 @@ def request(client, url, data):
     try:
 
         response = requests.post(url,
-                                 data=json.dumps(data),
+                                 data=json.dumps(data, cls=DatetimeSerializer),
                                  headers={'content-type': 'application/json'},
                                  timeout=client.timeout)
 

--- a/analytics/utils.py
+++ b/analytics/utils.py
@@ -1,4 +1,4 @@
-
+import json
 from datetime import datetime
 from dateutil.tz import tzlocal, tzutc
 
@@ -24,3 +24,10 @@ def guess_timezone(dt):
             return dt.replace(tzinfo=tzutc())
 
     return dt
+
+class DatetimeSerializer(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+
+        return json.JSONEncoder.default(self, obj)

--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 import unittest
+import json
 
 from datetime import datetime, timedelta
 
@@ -78,6 +79,15 @@ class AnalyticsBasicTests(unittest.TestCase):
         analytics.default_client._clean(combined)
 
         self.assertEqual(combined.keys(), pre_clean_keys)
+        
+    def test_datetime_serialization(self):
+        
+        data = {
+            'created': datetime(2012, 3, 4, 5, 6, 7, 891011),
+        }
+        result = json.dumps(data, cls=analytics.utils.DatetimeSerializer)
+        
+        self.assertEqual(result, '{"created": "2012-03-04T05:06:07.891011"}')
 
     def test_async_basic_identify(self):
         # flush after every message


### PR DESCRIPTION
Hey guys,

I've added a DatetimeSerializer class to utils.py, which can be used to serialise datetimes (and dates/times etc) to JSON in the request. 

I've also added a sample test case (and made the test script executable). 

Have you thought about running your test case automatically using something like [Travis CI](about.travis-ci.org/docs/user/languages/python/)? Edit: Never mind - I see you're using it, although there seems to be no `.travis.yml` file.
