### PR TITLE
make it really testable

### DIFF
--- a/analytics/client.py
+++ b/analytics/client.py
@@ -37,7 +37,9 @@ class Client(object):
         if debug:
             self.log.setLevel('DEBUG')
 
-        self.consumer.start()
+        # if we've disabled sending, just don't start the consumer
+        if send:
+            self.consumer.start()
 
     def identify(self, user_id=None, traits={}, context={}, timestamp=None,
                  anonymous_id=None, integrations={}):
@@ -180,10 +182,6 @@ class Client(object):
         }
 
         clean(msg)
-
-        # if we've disabled sending, just return False
-        if not self.send:
-            return False, msg
 
         if self.queue.full():
             self.log.warn('analytics-python queue is full')


### PR DESCRIPTION
I think that that the send toggle provided by PR  #31 would be much better if instead of not queuing it would rather not start the Consumer thread. 
It  provides fast execution (enqueing is fast, consuming is not) as in the original implementation, but it also provides a better solution for testing (on the client side).

With this patch you are able to test that the messages are correctly written in the queue, with the expected metadata. 