### PR TITLE
Support HTTP keep-alive using a Session connection pool

### DIFF
--- a/analytics/request.py
+++ b/analytics/request.py
@@ -4,7 +4,9 @@ import logging
 import json
 
 from requests.auth import HTTPBasicAuth
-import requests
+from requests import sessions
+
+_session = sessions.Session()
 
 
 def post(write_key, **kwargs):
@@ -17,7 +19,7 @@ def post(write_key, **kwargs):
     data = json.dumps(body, cls=DatetimeSerializer)
     headers = { 'content-type': 'application/json' }
     log.debug('making request: %s', data)
-    res = requests.post(url, data=data, auth=auth, headers=headers, timeout=15)
+    res = _session.post(url, data=data, auth=auth, headers=headers, timeout=15)
 
     if res.status_code == 200:
         log.debug('data uploaded successfully')


### PR DESCRIPTION
```
$ python -m timeit -s "import requests" "requests.head('https://graingert.co.uk')"
10 loops, best of 3: 199 msec per loop
$ python -m timeit -s "import requests; sess=requests.session()" "sess.head('https://graingert.co.uk')"
10 loops, best of 3: 136 msec per loop
```