### PR TITLE
Added "join" functionn to the client. It blocks program until the que…

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -41,6 +41,10 @@ def flush():
     """Tell the client to flush."""
     _proxy('flush')
 
+def join():
+    """Block program until the client clears the queue"""
+    _proxy('join')
+
 def _proxy(method, *args, **kwargs):
     """Create an analytics client if one doesn't exist and send to it."""
     global default_client

--- a/analytics/client.py
+++ b/analytics/client.py
@@ -199,6 +199,13 @@ class Client(object):
         self.log.debug('successfully flushed {0} items.'.format(size))
 
 
+    def join(self):
+        """Ends the consumer thread once the queue is empty. Blocks execution until finished"""
+        self.consumer.pause()
+        self.consumer.join()
+
+
+
 def require(name, field, data_type):
     """Require that the named `field` has the right `data_type`"""
     if not isinstance(field, data_type):


### PR DESCRIPTION
When developing for Google App Engine, the thread often didn't finish before the web request did. GAE doesn't like any leftover threads and I had to implement this (see attached screenshot for the error details).

Ideally, I'd love an option for the analytics to have a "blocking" option upon client initiation - GAE has it's own *deferred* library for running things in the background, past the web request.

![screen shot 2015-06-17 at 14 14 40](https://cloud.githubusercontent.com/assets/274250/8206591/47f78724-14fb-11e5-903d-3a667acefdde.png)

