### PR TITLE
Adding fixes for handling invalid json types

### DIFF
--- a/analytics/client.py
+++ b/analytics/client.py
@@ -181,7 +181,8 @@ class Client(object):
             'version': VERSION
         }
 
-        clean(msg)
+        msg = clean(msg)
+        self.log.debug('queueing: %s', msg)
 
         if self.queue.full():
             self.log.warn('analytics-python queue is full')
@@ -197,7 +198,6 @@ class Client(object):
         size = queue.qsize()
         queue.join()
         self.log.debug('successfully flushed {0} items.'.format(size))
-
 
     def join(self):
         """Ends the consumer thread once the queue is empty. Blocks execution until finished"""

--- a/analytics/test/utils.py
+++ b/analytics/test/utils.py
@@ -56,3 +56,10 @@ class TestUtils(unittest.TestCase):
             item = bytearray(10)
 
         utils.clean(item)
+
+    def test_clean_fn(self):
+        cleaned = utils.clean({ 'fn': lambda x: x, 'number': 4 })
+        self.assertEqual(cleaned['number'], 4)
+        # TODO: fixme, different behavior on python 2 and 3
+        if 'fn' in cleaned:
+            self.assertEqual(cleaned['fn'], None)

--- a/analytics/utils.py
+++ b/analytics/utils.py
@@ -5,6 +5,8 @@ import numbers
 
 import six
 
+log = logging.getLogger('segment')
+
 
 def is_naive(dt):
     """Determines if a given datetime.datetime is naive."""
@@ -51,7 +53,6 @@ def _clean_dict(dict_):
         try:
             data[k] = clean(v)
         except TypeError:
-            log = logging.getLogger('segment')
             log.warning('Dictionary values must be serializeable to ' +
                         'JSON "%s" value %s of type %s is unsupported.'
                         % (k, v, type(v)))
@@ -63,6 +64,8 @@ def _coerce_unicode(cmplx):
     except AttributeError as exception:
         item = ":".join(exception)
         item.decode("utf-8", "strict")
+        log.warning('Error decoding: %s', item)
+        return None
     except:
         raise
     return item

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'analytics'))
 from version import VERSION
 
 long_description = '''
-Segment.io is the simplest way to integrate analytics into your application.
+Segment is the simplest way to integrate analytics into your application.
 One API allows you to turn on any other analytics service. No more learning
 new APIs, repeated code, and wasted development time.
 
-This is the official python client that wraps the Segment.io REST API (https://segment.io).
+This is the official python client that wraps the Segment REST API (https://segment.com).
 
 Documentation and more details at https://github.com/segmentio/analytics-python
 '''


### PR DESCRIPTION
Previously invalid json types weren't being modified and would
end up simply stringifying the field. Now the fields are actually
modified and removed so that they don't pollute analytics.