### PR TITLE
Clean Decimals from message

### DIFF
--- a/analytics/utils.py
+++ b/analytics/utils.py
@@ -1,5 +1,6 @@
 from dateutil.tz import tzlocal, tzutc
 from datetime import datetime
+from decimal import Decimal
 import logging
 import numbers
 
@@ -34,7 +35,9 @@ def guess_timezone(dt):
     return dt
 
 def clean(item):
-    if isinstance(item, (six.string_types, bool, numbers.Number, datetime,
+    if isinstance(item, Decimal):
+        return float(item)
+    elif isinstance(item, (six.string_types, bool, numbers.Number, datetime,
                          type(None))):
         return item
     elif isinstance(item, (set, list, tuple)):


### PR DESCRIPTION
Decimals are not JSON serializable, but are not currently cleaned.  This solution uses floating point conversion, though using a custom JSONEncoder that provides exact string conversion of the Decimal could be preferable, depending on the server-side solution or in case any prices are included.

Closes #63