### PR TITLE
Use proper way for defining conditional dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ install_requires = [
     "six>=1.5"
 ]
 
-if sys.version_info <= (3,0):
-    install_requires.append('python-dateutil>=1,<2')
-else:
-    install_requires.append('python-dateutil>2')
+extras_require={
+    ':python_version<="3.0"': ['python-dateutil>=1,<2'],
+    ':python_version>"3.0"': ['python-dateutil>2']
+}
 
 setup(
     name='analytics-python',
@@ -43,6 +43,7 @@ setup(
     packages=['analytics', 'analytics.test'],
     license='MIT License',
     install_requires=install_requires,
+    extras_require=extras_require,
     description='The hassle-free way to integrate analytics into any python application.',
     long_description=long_description,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ install_requires = [
 ]
 
 extras_require={
-    ':python_version<="3.0"': ['python-dateutil>=1,<2'],
-    ':python_version>"3.0"': ['python-dateutil>2']
+    ':python_version in "2.6, 2.7"': ['python-dateutil>=1,<2'],
+    ':python_version in "3.2, 3.3, 3.4, 3.5"': ['python-dateutil>2']
 }
 
 setup(


### PR DESCRIPTION
We always installed a wrong version of python-dateutil (>=1,<2) for Python 3 with
the previous version of setup.py when using wheel package.
So we must use another solution which is described here
https://wheel.readthedocs.org/en/latest/#defining-conditional-dependencies