### PR TITLE
Don't limit the upper bound of requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ Documentation and more details at https://github.com/segmentio/analytics-python
 '''
 
 install_requires = [
-    "requests>=2.7,<2.8",
+    "requests>=2.7",
     "six>=1.5"
 ]
 


### PR DESCRIPTION
Unless there's a very good reason to put a limit on the upper bound of the dependencies in a library, it's good practice to not include those. We're using a higher version of requests because we have another dependency that relies on new requests>=2.9 features, so now there's an unresolvable conflict.