### PR TITLE
Join (and close) daemon thread on interpreter exit

### DIFF
--- a/analytics/client.py
+++ b/analytics/client.py
@@ -38,7 +38,8 @@ class Client(object):
         # On program exit, allow the consumer thread to exit cleanly.
         # This prevents exceptions and a messy shutdown when the interpreter is
         # destroyed before the daemon thread finishes execution. However, it
-        # is *not* the same as flushing the queue! To guarantee all
+        # is *not* the same as flushing the queue! To guarantee all messages
+        # have been delivered, you'll still need to call flush().
         atexit.register(self.join)
 
         if debug:

--- a/analytics/client.py
+++ b/analytics/client.py
@@ -210,13 +210,13 @@ class Client(object):
         msg = clean(msg)
         self.log.debug('queueing: %s', msg)
 
-        if self.queue.full():
+        try:
+            self.queue.put(msg, block=False)
+            self.log.debug('enqueued %s.', msg['type'])
+            return True, msg
+        except queue.Full:
             self.log.warn('analytics-python queue is full')
             return False, msg
-
-        self.queue.put(msg)
-        self.log.debug('enqueued %s.', msg['type'])
-        return True, msg
 
     def flush(self):
         """Forces a flush from the internal queue to the server"""

--- a/analytics/client.py
+++ b/analytics/client.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from uuid import uuid4
 import logging
 import numbers
+import atexit
 
 from dateutil.tz import tzutc
 from six import string_types
@@ -33,6 +34,12 @@ class Client(object):
         self.on_error = on_error
         self.debug = debug
         self.send = send
+
+        # On program exit, allow the consumer thread to exit cleanly.
+        # This prevents exceptions and a messy shutdown when the interpreter is
+        # destroyed before the daemon thread finishes execution. However, it
+        # is *not* the same as flushing the queue! To guarantee all
+        atexit.register(self.join)
 
         if debug:
             self.log.setLevel(logging.DEBUG)
@@ -215,7 +222,8 @@ class Client(object):
         queue = self.queue
         size = queue.qsize()
         queue.join()
-        self.log.debug('successfully flushed %s items.', size)
+        # Note that this message may not be precise, because of threading.
+        self.log.debug('successfully flushed about %s items.', size)
 
     def join(self):
         """Ends the consumer thread once the queue is empty. Blocks execution until finished"""

--- a/analytics/consumer.py
+++ b/analytics/consumer.py
@@ -22,12 +22,15 @@ class Consumer(Thread):
         self.write_key = write_key
         self.on_error = on_error
         self.queue = queue
+        # It's important to set running in the constructor: if we are asked to
+        # pause immediately after construction, we might set running to True in
+        # run() *after* we set it to False in pause... and keep running forever.
+        self.running = True
         self.retries = 3
 
     def run(self):
         """Runs the consumer."""
         self.log.debug('consumer is running...')
-        self.running = True
         while self.running:
             self.upload()
 

--- a/analytics/consumer.py
+++ b/analytics/consumer.py
@@ -16,7 +16,8 @@ class Consumer(Thread):
     def __init__(self, queue, write_key, upload_size=100, on_error=None):
         """Create a consumer thread."""
         Thread.__init__(self)
-        self.daemon = True # set as a daemon so the program can exit
+        # Make consumer a daemon thread so that it doesn't block program exit
+        self.daemon = True
         self.upload_size = upload_size
         self.write_key = write_key
         self.on_error = on_error

--- a/analytics/test/client.py
+++ b/analytics/test/client.py
@@ -208,23 +208,25 @@ class TestClient(unittest.TestCase):
 
     def test_flush(self):
         client = self.client
-        # send a few more requests than a single batch will allow
-        for i in range(60):
+        # set up the consumer with more requests than a single batch will allow
+        for i in range(1000):
             success, msg = client.identify('userId', { 'trait': 'value' })
-
-        self.assertFalse(client.queue.empty())
+        # We can't reliably assert that the queue is non-empty here; that's
+        # a race condition. We do our best to load it up though.
         client.flush()
+        # Make sure that the client queue is empty after flushing
         self.assertTrue(client.queue.empty())
 
     def test_overflow(self):
         client = Client('testsecret', max_queue_size=1)
         client.consumer.pause()
-        time.sleep(5.1) # allow time for consumer to exit
+        time.sleep(1.0) # allow time for consumer to exit
 
         for i in range(10):
           client.identify('userId')
 
         success, msg = client.identify('userId')
+        # Make sure we are informed that the queue is at capacity
         self.assertFalse(success)
 
     def test_success_on_invalid_write_key(self):

--- a/analytics/test/client.py
+++ b/analytics/test/client.py
@@ -219,8 +219,8 @@ class TestClient(unittest.TestCase):
 
     def test_overflow(self):
         client = Client('testsecret', max_queue_size=1)
-        client.consumer.pause()
-        time.sleep(1.0) # allow time for consumer to exit
+        # Ensure consumer thread is no longer uploading
+        client.join()
 
         for i in range(10):
           client.identify('userId')


### PR DESCRIPTION
This allows the message sending queue to clean up nicely and prevents
an error as the interpreter is destroyed. If you are exiting
intentionally you should still call flush() to ensure all your messages
are delivered -- this doesn't change that behavior. We also change the
blocking semantics on the delivery thread here to deliver messages in a more
efficient manner.

Fixes #46.
Fixes #69.