### PR TITLE
fix outdated python-dateutil<2 requirement for python2 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,13 +23,9 @@ Documentation and more details at https://github.com/segmentio/analytics-python
 
 install_requires = [
     "requests>=2.7,<3.0",
-    "six>=1.5"
+    "six>=1.5",
+    "python-dateutil>2.1"
 ]
-
-extras_require={
-    ':python_version in "2.6, 2.7"': ['python-dateutil>=1,<2'],
-    ':python_version in "3.2, 3.3, 3.4, 3.5"': ['python-dateutil>2']
-}
 
 setup(
     name='analytics-python',
@@ -43,7 +39,6 @@ setup(
     packages=['analytics', 'analytics.test'],
     license='MIT License',
     install_requires=install_requires,
-    extras_require=extras_require,
     description='The hassle-free way to integrate analytics into any python application.',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
cf https://github.com/segmentio/analytics-python/issues/78 - python-dateutil>2.1 is python2 compatible and most other packages using dateutil now require python-dateutil > 2.1 so we end up having conflicting requirements for no good reasons. 