### PR TITLE
Changed atexit.register when send=False

### DIFF
--- a/analytics/client.py
+++ b/analytics/client.py
@@ -35,18 +35,17 @@ class Client(object):
         self.debug = debug
         self.send = send
 
-        # On program exit, allow the consumer thread to exit cleanly.
-        # This prevents exceptions and a messy shutdown when the interpreter is
-        # destroyed before the daemon thread finishes execution. However, it
-        # is *not* the same as flushing the queue! To guarantee all messages
-        # have been delivered, you'll still need to call flush().
-        atexit.register(self.join)
-
         if debug:
             self.log.setLevel(logging.DEBUG)
 
         # if we've disabled sending, just don't start the consumer
         if send:
+            # On program exit, allow the consumer thread to exit cleanly.
+            # This prevents exceptions and a messy shutdown when the interpreter is
+            # destroyed before the daemon thread finishes execution. However, it
+            # is *not* the same as flushing the queue! To guarantee all messages
+            # have been delivered, you'll still need to call flush().
+            atexit.register(self.join)
             self.consumer.start()
 
     def identify(self, user_id=None, traits=None, context=None, timestamp=None,


### PR DESCRIPTION
When ```atexist.register(self.join)``` is called with ```send=False```, it raises an error since the thread is not running.

Using ```python3.5``` with the ```send=False```.

```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "D:\Python35\lib\site-packages\analytics\client.py", line 232, in join
    self.consumer.join()
  File "D:\Python35\lib\threading.py", line 1058, in join
    raise RuntimeError("cannot join thread before it is started")
RuntimeError: cannot join thread before it is started
```

There is no reason to execute ```self.join``` if the thread is not running, so I moved the ```atexit.register(self.join)``` with the ```if send:```