### PR TITLE
consumer thread may not have even started before `consumer.join()` is called

### DIFF
--- a/analytics/client.py
+++ b/analytics/client.py
@@ -229,7 +229,11 @@ class Client(object):
     def join(self):
         """Ends the consumer thread once the queue is empty. Blocks execution until finished"""
         self.consumer.pause()
-        self.consumer.join()
+        try:
+            self.consumer.join()
+        except RuntimeError:
+            # consumer thread has not started
+            pass
 
 
 def require(name, field, data_type):


### PR DESCRIPTION
related to https://github.com/segmentio/analytics-python/pull/80, I think if that one merges, this will be less necessary

the client consumer thread may not be running before `join()` is called
```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/Users/diwu/.virtualenvs/BetterWorks/lib/python2.7/site-packages/analytics/client.py", line 232, in join
    self.consumer.join()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 938, in join
    raise RuntimeError("cannot join thread before it is started")
RuntimeError: cannot join thread before it is started
Error in sys.exitfunc:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/Users/diwu/.virtualenvs/BetterWorks/lib/python2.7/site-packages/analytics/client.py", line 232, in join
    self.consumer.join()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 938, in join
    raise RuntimeError("cannot join thread before it is started")
RuntimeError: cannot join thread before it is started
```
https://docs.python.org/2/library/threading.html#threading.Thread.join
![image](https://cloud.githubusercontent.com/assets/380950/16371225/fd4b18f4-3bf9-11e6-8167-db4847a82337.png)
