### PR TITLE
Fix date object conversion

### DIFF
--- a/analytics/test/utils.py
+++ b/analytics/test/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 from decimal import Decimal
 import unittest
 
@@ -26,7 +26,8 @@ class TestUtils(unittest.TestCase):
         simple = {
             'decimal': Decimal('0.142857'),
             'unicode': six.u('woo'),
-            'date': datetime.now(),
+            'datetime': datetime.now(),
+            'date': date.today(),
             'long': 200000000,
             'integer': 1,
             'float': 2.0,

--- a/analytics/utils.py
+++ b/analytics/utils.py
@@ -1,5 +1,6 @@
 from dateutil.tz import tzlocal, tzutc
 from datetime import datetime
+from datetime import date
 from decimal import Decimal
 import logging
 import numbers
@@ -40,6 +41,8 @@ def clean(item):
     elif isinstance(item, (six.string_types, bool, numbers.Number, datetime,
                          type(None))):
         return item
+    elif isinstance(item, date):
+        return datetime.combine(item, datetime.min.time())
     elif isinstance(item, (set, list, tuple)):
         return _clean_list(item)
     elif isinstance(item, dict):


### PR DESCRIPTION
In order to avoid:
`Error decoding: 'datetime.date' object has no attribute 'decode'` when the item is treated as text and not date object.
