### PR TITLE
Disable SSL Cert verification

### DIFF
--- a/analytics/request.py
+++ b/analytics/request.py
@@ -19,7 +19,7 @@ def post(write_key, **kwargs):
     data = json.dumps(body, cls=DatetimeSerializer)
     headers = { 'content-type': 'application/json' }
     log.debug('making request: %s', data)
-    res = _session.post(url, data=data, auth=auth, headers=headers, timeout=15)
+    res = _session.post(url, data=data, auth=auth, headers=headers, timeout=15, verify=False)
 
     if res.status_code == 200:
         log.debug('data uploaded successfully')


### PR DESCRIPTION
If you are running on AWS Lambda you will get a weird error that turns out to be an SSL error from the underlying requests library used. See Issue #89 

This patch disables SSL verification so that error doesn't occur and you can at least send events.

THIS IS NOT IDEAL FOR SECURITY REASONS