### PR TITLE
Stringify userId and anonymousId

### DIFF
--- a/analytics/client.py
+++ b/analytics/client.py
@@ -206,6 +206,9 @@ class Client(object):
             'version': VERSION
         }
 
+        msg['userId'] = stringify_id(msg.get('userId', None))
+        msg['anonymousId'] = stringify_id(msg.get('anonymousId', None))
+
         msg = clean(msg)
         self.log.debug('queueing: %s', msg)
 
@@ -244,3 +247,10 @@ def require(name, field, data_type):
     if not isinstance(field, data_type):
         msg = '{0} must have {1}, got: {2}'.format(name, data_type, field)
         raise AssertionError(msg)
+
+def stringify_id(val):
+    if val is None:
+        return None
+    if isinstance(val, string_types):
+        return val
+    return str(val)

--- a/analytics/test/client.py
+++ b/analytics/test/client.py
@@ -37,6 +37,30 @@ class TestClient(unittest.TestCase):
         self.assertEqual(msg['properties'], {})
         self.assertEqual(msg['type'], 'track')
 
+    def test_stringifies_user_id(self):
+        # A large number that loses precision in node:
+        # node -e "console.log(157963456373623802 + 1)" > 157963456373623800
+        client = self.client
+        success, msg = client.track(user_id = 157963456373623802, event = 'python test event')
+        client.flush()
+        self.assertTrue(success)
+        self.assertFalse(self.failed)
+
+        self.assertEqual(msg['userId'], '157963456373623802')
+        self.assertEqual(msg['anonymousId'], None)
+
+    def test_stringifies_anonymous_id(self):
+        # A large number that loses precision in node:
+        # node -e "console.log(157963456373623803 + 1)" > 157963456373623800
+        client = self.client
+        success, msg = client.track(anonymous_id = 157963456373623803, event = 'python test event')
+        client.flush()
+        self.assertTrue(success)
+        self.assertFalse(self.failed)
+
+        self.assertEqual(msg['userId'], None)
+        self.assertEqual(msg['anonymousId'], '157963456373623803')
+
     def test_advanced_track(self):
         client = self.client
         success, msg = client.track(


### PR DESCRIPTION
Ref: https://segment.atlassian.net/browse/LIB-27

Our API truncates bignum values. This is problematic because this library has historically accepted Numbers as userIds and anonymousIds. TTo workaround the truncation, this library needs to stringify userId and anonymousId on the client.

The test cases are numbers that will be truncated in Node, e.g. `node -e "console.log(157963456373623802 + 1)"`.