### PR TITLE
Allow user-defined upload interval

### DIFF
--- a/analytics/client.py
+++ b/analytics/client.py
@@ -25,11 +25,12 @@ class Client(object):
     log = logging.getLogger('segment')
 
     def __init__(self, write_key=None, host=None, debug=False, max_queue_size=10000,
-                 send=True, on_error=None):
+                 send=True, on_error=None, upload_interval=0.5):
         require('write_key', write_key, string_types)
 
         self.queue = queue.Queue(max_queue_size)
-        self.consumer = Consumer(self.queue, write_key, host=host, on_error=on_error)
+        self.consumer = Consumer(self.queue, write_key, host=host, on_error=on_error,
+                                 upload_interval=upload_interval)
         self.write_key = write_key
         self.on_error = on_error
         self.debug = debug

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ Documentation and more details at https://github.com/segmentio/analytics-python
 install_requires = [
     "requests>=2.7,<3.0",
     "six>=1.5",
+    "monotonic>=1.5",
     "python-dateutil>2.1"
 ]
 


### PR DESCRIPTION
Upload interval now can be specified as a parameter in Client. Default
value is 0.5s, which should yield similar upload frequency with previous
versions.