### PR TITLE
Add exponential backoff with jitter when retrying

### DIFF
--- a/analytics/client.py
+++ b/analytics/client.py
@@ -25,12 +25,12 @@ class Client(object):
     log = logging.getLogger('segment')
 
     def __init__(self, write_key=None, host=None, debug=False, max_queue_size=10000,
-                 send=True, on_error=None, upload_interval=0.5):
+                 send=True, on_error=None, upload_interval=0.5, max_retries=10):
         require('write_key', write_key, string_types)
 
         self.queue = queue.Queue(max_queue_size)
         self.consumer = Consumer(self.queue, write_key, host=host, on_error=on_error,
-                                 upload_interval=upload_interval)
+                                 upload_interval=upload_interval, retries=max_retries)
         self.write_key = write_key
         self.on_error = on_error
         self.debug = debug

--- a/analytics/consumer.py
+++ b/analytics/consumer.py
@@ -98,7 +98,7 @@ class Consumer(Thread):
                 # retry on all other errors (eg. network)
                 return False
 
-        @backoff.on_exception(backoff.expo, Exception, max_tries=self.retries+1, giveup=fatal_exception)
+        @backoff.on_exception(backoff.expo, Exception, max_tries=self.retries + 1, giveup=fatal_exception)
         def send_request():
             post(self.write_key, self.host, batch=batch)
 

--- a/analytics/consumer.py
+++ b/analytics/consumer.py
@@ -98,7 +98,7 @@ class Consumer(Thread):
                 # retry on all other errors (eg. network)
                 return False
 
-        @backoff.on_exception(backoff.expo, Exception, max_tries=self.retries, giveup=fatal_exception)
+        @backoff.on_exception(backoff.expo, Exception, max_tries=self.retries+1, giveup=fatal_exception)
         def send_request():
             post(self.write_key, self.host, batch=batch)
 

--- a/analytics/consumer.py
+++ b/analytics/consumer.py
@@ -1,21 +1,23 @@
 import logging
 from threading import Thread
 import monotonic
+import backoff
 
 from analytics.version import VERSION
 from analytics.request import post, APIError
 
 try:
     from queue import Empty
-except:
+except ImportError:
     from Queue import Empty
+
 
 class Consumer(Thread):
     """Consumes the messages from the client's queue."""
     log = logging.getLogger('segment')
 
     def __init__(self, queue, write_key, upload_size=100, host=None, on_error=None,
-                 upload_interval=0.5):
+                 upload_interval=0.5, retries=10):
         """Create a consumer thread."""
         Thread.__init__(self)
         # Make consumer a daemon thread so that it doesn't block program exit
@@ -30,7 +32,7 @@ class Consumer(Thread):
         # pause immediately after construction, we might set running to True in
         # run() *after* we set it to False in pause... and keep running forever.
         self.running = True
-        self.retries = 3
+        self.retries = retries
 
     def run(self):
         """Runs the consumer."""
@@ -84,24 +86,20 @@ class Consumer(Thread):
 
         return items
 
-    def request(self, batch, attempt=0):
+    def request(self, batch):
         """Attempt to upload the batch and retry before raising an error """
-        try:
-            post(self.write_key, self.host, batch=batch)
-        except Exception as exc:
-            def maybe_retry():
-                if attempt >= self.retries:
-                    raise
-                self.request(batch, attempt+1)
 
+        def fatal_exception(exc):
             if isinstance(exc, APIError):
-                if exc.status >= 500 or exc.status == 429:
-                    # retry on server errors and client errors with 429 status code (rate limited)
-                    maybe_retry()
-                elif exc.status >= 400: # don't retry on other client errors
-                    self.log.error('API error: %s', exc)
-                    raise
-                else:
-                    self.log.debug('Unexpected APIError: %s', exc)
-            else: # retry on all other errors (eg. network)
-                maybe_retry()
+                # retry on server errors and client errors with 429 status code (rate limited),
+                # don't retry on other client errors
+                return (400 <= exc.status < 500) and exc.status != 429
+            else:
+                # retry on all other errors (eg. network)
+                return False
+
+        @backoff.on_exception(backoff.expo, Exception, max_tries=self.retries, giveup=fatal_exception)
+        def send_request():
+            post(self.write_key, self.host, batch=batch)
+
+        send_request()

--- a/analytics/test/consumer.py
+++ b/analytics/test/consumer.py
@@ -96,7 +96,7 @@ class TestConsumer(unittest.TestCase):
         mock_post.call_count = 0
 
         with mock.patch('analytics.consumer.post', mock.Mock(side_effect=mock_post)):
-            consumer = Consumer(None, 'testsecret')
+            consumer = Consumer(None, 'testsecret', retries=3)
             track = {
                 'type': 'track',
                 'event': 'python event',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ install_requires = [
     "requests>=2.7,<3.0",
     "six>=1.5",
     "monotonic>=1.5",
+    "backoff==1.6.0",
     "python-dateutil>2.1"
 ]
 


### PR DESCRIPTION
* Space out request retries with exponential backoff and full jitter
* Change default number of retries from 3 to 10