### PR TITLE
Allows more settings to be configured from the singleton

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -5,12 +5,18 @@ from analytics.client import Client
 __version__ = VERSION
 
 """Settings."""
-write_key = None
-host = None
-on_error = None
-debug = False
-send = True
-sync_mode = False
+write_key = Client.DefaultConfig.write_key
+host = Client.DefaultConfig.host
+on_error = Client.DefaultConfig.on_error
+debug = Client.DefaultConfig.debug
+send = Client.DefaultConfig.send
+sync_mode = Client.DefaultConfig.sync_mode
+upload_size = Client.DefaultConfig.upload_size
+upload_interval = Client.DefaultConfig.upload_interval
+max_queue_size = Client.DefaultConfig.max_queue_size
+gzip = Client.DefaultConfig.gzip
+timeout = Client.DefaultConfig.timeout
+max_retries = Client.DefaultConfig.max_retries
 
 default_client = None
 
@@ -58,8 +64,9 @@ def _proxy(method, *args, **kwargs):
     """Create an analytics client if one doesn't exist and send to it."""
     global default_client
     if not default_client:
-        default_client = Client(write_key, host=host, debug=debug, on_error=on_error,
-                                send=send, sync_mode=sync_mode)
+        default_client = Client(write_key, host=host, debug=debug, max_queue_size=max_queue_size,
+                                send=send, on_error=on_error, upload_size=upload_size, upload_interval=upload_interval,
+                                gzip=gzip, max_retries=max_retries, sync_mode=sync_mode, timeout=timeout)
 
     fn = getattr(default_client, method)
     fn(*args, **kwargs)

--- a/analytics/client.py
+++ b/analytics/client.py
@@ -22,12 +22,38 @@ ID_TYPES = (numbers.Number, string_types)
 
 
 class Client(object):
+    class DefaultConfig(object):
+        write_key = None
+        host = None
+        on_error = None
+        debug = False
+        send = True
+        sync_mode = False
+        upload_size = 100
+        upload_interval = 0.5
+        max_queue_size = 10000
+        gzip = False
+        timeout = 15
+        max_retries = 10
+
     """Create a new Segment client."""
     log = logging.getLogger('segment')
 
-    def __init__(self, write_key=None, host=None, debug=False, max_queue_size=10000,
-                 send=True, on_error=None, upload_size=100, upload_interval=0.5,
-                 gzip=False, max_retries=10, sync_mode=False, timeout=15):
+    def __init__(
+        self,
+        write_key=DefaultConfig.write_key,
+        host=DefaultConfig.host,
+        debug=DefaultConfig.debug,
+        max_queue_size=DefaultConfig.max_queue_size,
+        send=DefaultConfig.send,
+        on_error=DefaultConfig.on_error,
+        upload_size=DefaultConfig.upload_size,
+        upload_interval=DefaultConfig.upload_interval,
+        gzip=DefaultConfig.gzip,
+        max_retries=DefaultConfig.max_retries,
+        sync_mode=DefaultConfig.sync_mode,
+        timeout=DefaultConfig.timeout
+    ):
         require('write_key', write_key, string_types)
 
         self.queue = queue.Queue(max_queue_size)

--- a/analytics/test/__init__.py
+++ b/analytics/test/__init__.py
@@ -2,11 +2,91 @@ import unittest
 import pkgutil
 import logging
 import sys
+import analytics
+
 
 def all_names():
     for _, modname, _ in pkgutil.iter_modules(__path__):
         yield 'analytics.test.' + modname
 
+
 def all():
     logging.basicConfig(stream=sys.stderr)
     return unittest.defaultTestLoader.loadTestsFromNames(all_names())
+
+
+class TestInit(unittest.TestCase):
+    def test_writeKey(self):
+        self.assertIsNone(analytics.default_client)
+        analytics.flush()
+        self.assertEqual(analytics.default_client.write_key, 'test-init')
+
+    def test_debug(self):
+        self.assertIsNone(analytics.default_client)
+        analytics.debug = True
+        analytics.flush()
+        self.assertTrue(analytics.default_client.debug)
+        analytics.default_client = None
+        analytics.debug = False
+        analytics.flush()
+        self.assertFalse(analytics.default_client.debug)
+
+    def test_gzip(self):
+        self.assertIsNone(analytics.default_client)
+        analytics.gzip = True
+        analytics.flush()
+        self.assertTrue(analytics.default_client.gzip)
+        analytics.default_client = None
+        analytics.gzip = False
+        analytics.flush()
+        self.assertFalse(analytics.default_client.gzip)
+
+    def test_host(self):
+        self.assertIsNone(analytics.default_client)
+        analytics.host = 'test-host'
+        analytics.flush()
+        self.assertEqual(analytics.default_client.host, 'test-host')
+
+    def test_max_queue_size(self):
+        self.assertIsNone(analytics.default_client)
+        analytics.max_queue_size = 1337
+        analytics.flush()
+        self.assertEqual(analytics.default_client.queue.maxsize, 1337)
+
+    def test_max_retries(self):
+        self.assertIsNone(analytics.default_client)
+        analytics.max_retries = 42
+        analytics.flush()
+        self.assertEqual(analytics.default_client.consumer.retries, 42)
+
+    def test_sync_mode(self):
+        self.assertIsNone(analytics.default_client)
+        analytics.sync_mode = True
+        analytics.flush()
+        self.assertTrue(analytics.default_client.sync_mode)
+        analytics.default_client = None
+        analytics.sync_mode = False
+        analytics.flush()
+        self.assertFalse(analytics.default_client.sync_mode)
+
+    def test_timeout(self):
+        self.assertIsNone(analytics.default_client)
+        analytics.timeout = 1.234
+        analytics.flush()
+        self.assertEqual(analytics.default_client.timeout, 1.234)
+
+    def test_upload_interval(self):
+        self.assertIsNone(analytics.default_client)
+        analytics.upload_interval = 0.4567
+        analytics.flush()
+        self.assertEqual(analytics.default_client.consumer.upload_interval, 0.4567)
+
+    def test_upload_size(self):
+        self.assertIsNone(analytics.default_client)
+        analytics.upload_size = 8912
+        analytics.flush()
+        self.assertEqual(analytics.default_client.consumer.upload_size, 8912)
+
+    def setUp(self):
+        analytics.write_key = 'test-init'
+        analytics.default_client = None


### PR DESCRIPTION
Allow these settings to be configured and share the default configuration between `__init__.py` and `consumer.py`:
- `upload_size`
- `upload_interval`
- `max_queue_size`
- `gzip`
- `timeout`
- `max_retries`

---
Ref: https://segment.atlassian.net/browse/LIB-1437