### PR TITLE
Run tests for multiple versions of Python and fix CircleCI badge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,13 +73,19 @@ jobs:
     docker:
       - image: circleci/python:3.6.5-jessie
 
-  test_37:
-    <<: *test_34
+  test_37: &test_37
     docker:
       - image: python:3.7-alpine
+    steps:
+      - checkout
+      - run: apk add make
+      - run: pip install --user .
+      - run: pip install coverage pylint==1.9.3 pycodestyle
+      - run: make test
+      - run: make e2e_test
 
   test_38:
-    <<: *test_34
+    <<: *test_37
     docker:
       - image: python:3.8-alpine
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,21 +73,15 @@ jobs:
     docker:
       - image: circleci/python:3.6.5-jessie
 
-  test_37: &test_37
+  test_37:
+    <<: *test_34
     docker:
-      - image: python:3.7-alpine
-    steps:
-      - checkout
-      - run: apk add make
-      - run: pip install --user .
-      - run: pip install coverage pylint==1.9.3 pycodestyle
-      - run: make test
-      - run: make e2e_test
+      - image: circleci/python:3.7-stretch
 
   test_38:
-    <<: *test_37
+    <<: *test_34
     docker:
-      - image: python:3.8-alpine
+      - image: circleci/python:3.8-buster
 
   publish:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - checkout
       - run: pip install --user .
+      - run: sudo pip install setuptools coverage pylint==1.9.3 pycodestyle
+      - run: make test
       - run: make e2e_test
 
   test_34: &test_34

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,16 @@ jobs:
     docker:
       - image: circleci/python:3.6.5-jessie
 
+  test_37:
+    <<: *test_34
+    docker:
+      - image: python:3.7-alpine
+
+  test_38:
+    <<: *test_34
+    docker:
+      - image: python:3.8-alpine
+
   publish:
     docker:
       - image: circleci/python:3.6.5-jessie
@@ -100,6 +110,12 @@ workflows:
       - test_36:
           filters:
             <<: *taggedReleasesFilter
+      - test_37:
+          filters:
+            <<: *taggedReleasesFilter
+      - test_38:
+          filters:
+            <<: *taggedReleasesFilter
       - publish:
           requires:
             - build
@@ -107,6 +123,8 @@ workflows:
             - test_34
             - test_35
             - test_36
+            - test_37
+            - test_38
           filters:
             <<: *taggedReleasesFilter
             branches:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿analytics-python
 ==============
 
-[![Build Status](https://secure.gravatar.com/avatar?s=60)](https://circleci.com/gh/segmentio/analytics-python)
+[![Build Status](https://circleci.com/gh/segmentio/analytics-python.svg?style=svg)](https://circleci.com/gh/segmentio/analytics-python)
 
 analytics-python is a python client for [Segment](https://segment.com)
 
@@ -75,4 +75,3 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿analytics-python
 ==============
 
-[![Build Status](https://circleci.com/gh/segmentio/analytics-python.svg?style=svg)](https://circleci.com/gh/segmentio/analytics-python)
+[![CircleCI](https://circleci.com/gh/segmentio/analytics-python.svg?style=svg)](https://circleci.com/gh/segmentio/analytics-python)
 
 analytics-python is a python client for [Segment](https://segment.com)
 

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,8 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )


### PR DESCRIPTION
This PR will allow CircleCI to run tests for Python 2.7 all the way to Python 3.8

All tests properly running can be checked on: https://circleci.com/gh/pberganza-applaudostudios/analytics-python