### PR TITLE
Feature/configurable concurrency

### DIFF
--- a/analytics/test/client.py
+++ b/analytics/test/client.py
@@ -256,13 +256,14 @@ class TestClient(unittest.TestCase):
         # 1. client queue is empty
         # 2. consumer thread has stopped
         self.assertTrue(client.queue.empty())
-        self.assertFalse(client.consumer.is_alive())
+        for consumer in client.consumers:
+            self.assertFalse(consumer.is_alive())
 
     def test_synchronous(self):
         client = Client('testsecret', sync_mode=True)
 
         success, message = client.identify('userId')
-        self.assertIsNone(client.consumer)
+        self.assertFalse(client.consumers)
         self.assertTrue(client.queue.empty())
         self.assertTrue(success)
 
@@ -333,8 +334,10 @@ class TestClient(unittest.TestCase):
 
     def test_user_defined_timeout(self):
         client = Client('testsecret', timeout=10)
-        self.assertEquals(client.consumer.timeout, 10)
+        for consumer in client.consumers:
+            self.assertEquals(consumer.timeout, 10)
 
     def test_default_timeout_15(self):
         client = Client('testsecret')
-        self.assertEquals(client.consumer.timeout, 15)
+        for consumer in client.consumers:
+            self.assertEquals(consumer.timeout, 15)


### PR DESCRIPTION
This pull request will make it able to use a configurable number of threads (via the `thread` parameter on the Client init). Tests have been updated to take into account the multiple consumers created.

Client no longer has a `consumer` property. It has been replaced by `consumers`.

It may be used as
```python
from analytics import Client
client = Client('WRITE_KEY', thread=3)
```