### PR TITLE
Fix/linting errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,8 @@ jobs:
     steps:
       - checkout
       - run: pip install --user .
-      - run: sudo pip install setuptools coverage pylint==1.9.3 pycodestyle
+      - run: sudo pip install setuptools coverage pylint==1.9.3 pycodestyle flake8
+      - run: flake8 --max-complexity=10 ./analytics
       - run: make test
       - run: make e2e_test
 
@@ -61,7 +62,8 @@ jobs:
     steps:
       - checkout
       - run: pip install --user .
-      - run: sudo pip install coverage pylint==1.9.3 pycodestyle
+      - run: sudo pip install coverage pylint==1.9.3 pycodestyle flake8
+      - run: flake8 --max-complexity=10 ./analytics
       - run: make test
       - run: make e2e_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - checkout
       - run: pip install --user .
-      - run: sudo pip install coverage pylint==1.9.3 pycodestyle
+      - run: sudo pip install coverage pylint==1.9.3 flake8
       - run: make test
       - persist_to_workspace:
           root: .
@@ -19,7 +19,7 @@ jobs:
       - store_artifacts:
           path: pylint.out
       - store_artifacts:
-          path: pycodestyle.out
+          path: flake8.out
 
   coverage:
     docker:
@@ -51,7 +51,7 @@ jobs:
     steps:
       - checkout
       - run: pip install --user .
-      - run: sudo pip install setuptools coverage pylint==1.9.3 pycodestyle flake8
+      - run: sudo pip install setuptools coverage pylint==1.9.3 flake8
       - run:
           name: Linting with Flake8
           command: |
@@ -65,7 +65,7 @@ jobs:
     steps:
       - checkout
       - run: pip install --user .
-      - run: sudo pip install coverage pylint==1.9.3 pycodestyle flake8
+      - run: sudo pip install coverage pylint==1.9.3 flake8
       - run:
           name: Linting with Flake8
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,10 @@ jobs:
       - checkout
       - run: pip install --user .
       - run: sudo pip install setuptools coverage pylint==1.9.3 pycodestyle flake8
-      - run: flake8 --max-complexity=10 ./analytics
+      - run:
+          name: Linting with Flake8
+          command: |
+            git diff origin/master..HEAD analytics | flake8 --diff --max-complexity=10 analytics
       - run: make test
       - run: make e2e_test
 
@@ -63,7 +66,10 @@ jobs:
       - checkout
       - run: pip install --user .
       - run: sudo pip install coverage pylint==1.9.3 pycodestyle flake8
-      - run: flake8 --max-complexity=10 ./analytics
+      - run:
+          name: Linting with Flake8
+          command: |
+            git diff origin/master..HEAD analytics | flake8 --diff --max-complexity=10 analytics
       - run: make test
       - run: make e2e_test
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 test:
 	pylint --rcfile=.pylintrc --reports=y --exit-zero analytics | tee pylint.out
-	# fail on pycodestyle errors on the code change
-	git diff origin/master..HEAD analytics | pycodestyle --ignore=E501,W503 --diff --statistics --count
-	pycodestyle --ignore=E501,W503 --statistics analytics > pycodestyle.out || true
+	flake8 --max-complexity=10 --statistics analytics > flake8.out || true
 	coverage run --branch --include=analytics/\* --omit=*/test* setup.py test
 
 release:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 test:
 	pylint --rcfile=.pylintrc --reports=y --exit-zero analytics | tee pylint.out
 	# fail on pycodestyle errors on the code change
-	git diff origin/master..HEAD analytics | pycodestyle --ignore=E501 --diff --statistics --count
-	pycodestyle --ignore=E501 --statistics analytics > pycodestyle.out || true
+	git diff origin/master..HEAD analytics | pycodestyle --ignore=E501,W503 --diff --statistics --count
+	pycodestyle --ignore=E501,W503 --statistics analytics > pycodestyle.out || true
 	coverage run --branch --include=analytics/\* --omit=*/test* setup.py test
 
 release:

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -19,29 +19,36 @@ def track(*args, **kwargs):
     """Send a track call."""
     _proxy('track', *args, **kwargs)
 
+
 def identify(*args, **kwargs):
     """Send a identify call."""
     _proxy('identify', *args, **kwargs)
+
 
 def group(*args, **kwargs):
     """Send a group call."""
     _proxy('group', *args, **kwargs)
 
+
 def alias(*args, **kwargs):
     """Send a alias call."""
     _proxy('alias', *args, **kwargs)
+
 
 def page(*args, **kwargs):
     """Send a page call."""
     _proxy('page', *args, **kwargs)
 
+
 def screen(*args, **kwargs):
     """Send a screen call."""
     _proxy('screen', *args, **kwargs)
 
+
 def flush():
     """Tell the client to flush."""
     _proxy('flush')
+
 
 def join():
     """Block program until the client clears the queue"""
@@ -58,8 +65,9 @@ def _proxy(method, *args, **kwargs):
     """Create an analytics client if one doesn't exist and send to it."""
     global default_client
     if not default_client:
-        default_client = Client(write_key, host=host, debug=debug, on_error=on_error,
-                                send=send, sync_mode=sync_mode)
+        default_client = Client(write_key, host=host, debug=debug,
+                                on_error=on_error, send=send,
+                                sync_mode=sync_mode)
 
     fn = getattr(default_client, method)
     fn(*args, **kwargs)

--- a/analytics/client.py
+++ b/analytics/client.py
@@ -14,7 +14,7 @@ from analytics.version import VERSION
 
 try:
     import queue
-except:
+except ImportError:
     import Queue as queue
 
 
@@ -48,17 +48,20 @@ class Client(object):
             self.consumers = None
         else:
             # On program exit, allow the consumer thread to exit cleanly.
-            # This prevents exceptions and a messy shutdown when the interpreter is
-            # destroyed before the daemon thread finishes execution. However, it
-            # is *not* the same as flushing the queue! To guarantee all messages
-            # have been delivered, you'll still need to call flush().
+            # This prevents exceptions and a messy shutdown when the
+            # interpreter is destroyed before the daemon thread finishes
+            # execution. However, it is *not* the same as flushing the queue!
+            # To guarantee all messages have been delivered, you'll still need
+            # to call flush().
             if send:
                 atexit.register(self.join)
             for n in range(thread):
                 self.consumers = []
-                consumer = Consumer(self.queue, write_key, host=host, on_error=on_error,
-                                    flush_at=flush_at, flush_interval=flush_interval,
-                                    gzip=gzip, retries=max_retries, timeout=timeout)
+                consumer = Consumer(
+                    self.queue, write_key, host=host, on_error=on_error,
+                    flush_at=flush_at, flush_interval=flush_interval,
+                    gzip=gzip, retries=max_retries, timeout=timeout,
+                )
                 self.consumers.append(consumer)
 
                 # if we've disabled sending, just don't start the consumer
@@ -87,7 +90,8 @@ class Client(object):
         return self._enqueue(msg)
 
     def track(self, user_id=None, event=None, properties=None, context=None,
-              timestamp=None, anonymous_id=None, integrations=None, message_id=None):
+              timestamp=None, anonymous_id=None, integrations=None,
+              message_id=None):
         properties = properties or {}
         context = context or {}
         integrations = integrations or {}
@@ -129,7 +133,8 @@ class Client(object):
         return self._enqueue(msg)
 
     def group(self, user_id=None, group_id=None, traits=None, context=None,
-              timestamp=None, anonymous_id=None, integrations=None, message_id=None):
+              timestamp=None, anonymous_id=None, integrations=None,
+              message_id=None):
         traits = traits or {}
         context = context or {}
         integrations = integrations or {}
@@ -266,7 +271,9 @@ class Client(object):
         self.log.debug('successfully flushed about %s items.', size)
 
     def join(self):
-        """Ends the consumer thread once the queue is empty. Blocks execution until finished"""
+        """Ends the consumer thread once the queue is empty.
+        Blocks execution until finished
+        """
         for consumer in self.consumers:
             consumer.pause()
             try:

--- a/analytics/request.py
+++ b/analytics/request.py
@@ -30,11 +30,13 @@ def post(write_key, host=None, gzip=False, timeout=15, **kwargs):
         headers['Content-Encoding'] = 'gzip'
         buf = BytesIO()
         with GzipFile(fileobj=buf, mode='w') as gz:
-            # 'data' was produced by json.dumps(), whose default encoding is utf-8.
+            # 'data' was produced by json.dumps(),
+            # whose default encoding is utf-8.
             gz.write(data.encode('utf-8'))
         data = buf.getvalue()
 
-    res = _session.post(url, data=data, auth=auth, headers=headers, timeout=timeout)
+    res = _session.post(url, data=data, auth=auth,
+                        headers=headers, timeout=timeout)
 
     if res.status_code == 200:
         log.debug('data uploaded successfully')

--- a/analytics/test/__init__.py
+++ b/analytics/test/__init__.py
@@ -3,9 +3,11 @@ import pkgutil
 import logging
 import sys
 
+
 def all_names():
     for _, modname, _ in pkgutil.iter_modules(__path__):
         yield 'analytics.test.' + modname
+
 
 def all():
     logging.basicConfig(stream=sys.stderr)

--- a/analytics/test/client.py
+++ b/analytics/test/client.py
@@ -326,7 +326,8 @@ class TestClient(unittest.TestCase):
 
         # the post function should be called 2 times, with a batch size of 10
         # each time.
-        with mock.patch('analytics.consumer.post', side_effect=mock_post_fn) as mock_post:
+        with mock.patch('analytics.consumer.post', side_effect=mock_post_fn) \
+                as mock_post:
             for _ in range(20):
                 client.identify('userId', {'trait': 'value'})
             time.sleep(1)

--- a/analytics/test/consumer.py
+++ b/analytics/test/consumer.py
@@ -52,8 +52,9 @@ class TestConsumer(unittest.TestCase):
         self.assertTrue(success)
 
     def test_flush_interval(self):
-        # Put _n_ items in the queue, pausing a little bit more than _flush_interval_
-        # after each one. The consumer should upload _n_ times.
+        # Put _n_ items in the queue, pausing a little bit more than
+        # _flush_interval_ after each one.
+        # The consumer should upload _n_ times.
         q = Queue()
         flush_interval = 0.3
         consumer = Consumer(q, 'testsecret', flush_at=10,
@@ -71,8 +72,8 @@ class TestConsumer(unittest.TestCase):
             self.assertEqual(mock_post.call_count, 3)
 
     def test_multiple_uploads_per_interval(self):
-        # Put _flush_at*2_ items in the queue at once, then pause for _flush_interval_.
-        # The consumer should upload 2 times.
+        # Put _flush_at*2_ items in the queue at once, then pause for
+        # _flush_interval_. The consumer should upload 2 times.
         q = Queue()
         flush_interval = 0.5
         flush_at = 10
@@ -99,7 +100,8 @@ class TestConsumer(unittest.TestCase):
         }
         consumer.request([track])
 
-    def _test_request_retry(self, consumer, expected_exception, exception_count):
+    def _test_request_retry(self, consumer,
+                            expected_exception, exception_count):
 
         def mock_post(*args, **kwargs):
             mock_post.call_count += 1
@@ -107,26 +109,29 @@ class TestConsumer(unittest.TestCase):
                 raise expected_exception
         mock_post.call_count = 0
 
-        with mock.patch('analytics.consumer.post', mock.Mock(side_effect=mock_post)):
+        with mock.patch('analytics.consumer.post',
+                        mock.Mock(side_effect=mock_post)):
             track = {
                 'type': 'track',
                 'event': 'python event',
                 'userId': 'userId'
             }
-            # request() should succeed if the number of exceptions raised is less
-            # than the retries paramater.
+            # request() should succeed if the number of exceptions raised is
+            # less than the retries paramater.
             if exception_count <= consumer.retries:
                 consumer.request([track])
             else:
-                # if exceptions are raised more times than the retries parameter,
-                # we expect the exception to be returned to the caller.
+                # if exceptions are raised more times than the retries
+                # parameter, we expect the exception to be returned to
+                # the caller.
                 try:
                     consumer.request([track])
                 except type(expected_exception) as exc:
                     self.assertEqual(exc, expected_exception)
                 else:
                     self.fail(
-                        "request() should raise an exception if still failing after %d retries" % consumer.retries)
+                        "request() should raise an exception if still failing "
+                        "after %d retries" % consumer.retries)
 
     def test_request_retry(self):
         # we should retry on general errors
@@ -180,10 +185,12 @@ class TestConsumer(unittest.TestCase):
             res = mock.Mock()
             res.status_code = 200
             self.assertTrue(len(data.encode()) < 500000,
-                            'batch size (%d) exceeds 500KB limit' % len(data.encode()))
+                            'batch size (%d) exceeds 500KB limit'
+                            % len(data.encode()))
             return res
 
-        with mock.patch('analytics.request._session.post', side_effect=mock_post_fn) as mock_post:
+        with mock.patch('analytics.request._session.post',
+                        side_effect=mock_post_fn) as mock_post:
             consumer.start()
             for _ in range(0, n_msgs + 2):
                 q.put(track)

--- a/analytics/test/module.py
+++ b/analytics/test/module.py
@@ -26,7 +26,7 @@ class TestModule(unittest.TestCase):
         analytics.flush()
 
     def test_identify(self):
-        analytics.identify('userId', { 'email': 'user@email.com' })
+        analytics.identify('userId', {'email': 'user@email.com'})
         analytics.flush()
 
     def test_group(self):

--- a/analytics/test/request.py
+++ b/analytics/test/request.py
@@ -17,13 +17,15 @@ class TestRequests(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
 
     def test_invalid_request_error(self):
-        self.assertRaises(Exception, post, 'testsecret', 'https://api.segment.io', False, '[{]')
+        self.assertRaises(Exception, post, 'testsecret',
+                          'https://api.segment.io', False, '[{]')
 
     def test_invalid_host(self):
-        self.assertRaises(Exception, post, 'testsecret', 'api.segment.io/', batch=[])
+        self.assertRaises(Exception, post, 'testsecret',
+                          'api.segment.io/', batch=[])
 
     def test_datetime_serialization(self):
-        data = { 'created': datetime(2012, 3, 4, 5, 6, 7, 891011) }
+        data = {'created': datetime(2012, 3, 4, 5, 6, 7, 891011)}
         result = json.dumps(data, cls=DatetimeSerializer)
         self.assertEqual(result, '{"created": "2012-03-04T05:06:07.891011"}')
 
@@ -44,7 +46,7 @@ class TestRequests(unittest.TestCase):
 
     def test_should_timeout(self):
         with self.assertRaises(requests.ReadTimeout):
-            res = post('testsecret', batch=[{
+            post('testsecret', batch=[{
                 'userId': 'userId',
                 'event': 'python event',
                 'type': 'track'

--- a/analytics/test/utils.py
+++ b/analytics/test/utils.py
@@ -65,12 +65,14 @@ class TestUtils(unittest.TestCase):
         utils.clean(item)
 
     def test_clean_fn(self):
-        cleaned = utils.clean({ 'fn': lambda x: x, 'number': 4 })
+        cleaned = utils.clean({'fn': lambda x: x, 'number': 4})
         self.assertEqual(cleaned['number'], 4)
         # TODO: fixme, different behavior on python 2 and 3
         if 'fn' in cleaned:
             self.assertEqual(cleaned['fn'], None)
 
     def test_remove_slash(self):
-        self.assertEqual('http://segment.io', utils.remove_trailing_slash('http://segment.io/'))
-        self.assertEqual('http://segment.io', utils.remove_trailing_slash('http://segment.io'))
+        self.assertEqual('http://segment.io',
+                         utils.remove_trailing_slash('http://segment.io/'))
+        self.assertEqual('http://segment.io',
+                         utils.remove_trailing_slash('http://segment.io'))

--- a/analytics/utils.py
+++ b/analytics/utils.py
@@ -13,10 +13,13 @@ def is_naive(dt):
     """Determines if a given datetime.datetime is naive."""
     return dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None
 
+
 def total_seconds(delta):
     """Determines total seconds with python < 2.7 compat."""
     # http://stackoverflow.com/questions/3694835/python-2-6-5-divide-timedelta-with-timedelta
-    return (delta.microseconds + (delta.seconds + delta.days * 24 * 3600) * 1e6) / 1e6
+    return (delta.microseconds
+            + (delta.seconds + delta.days * 24 * 3600) * 1e6) / 1e6
+
 
 def guess_timezone(dt):
     """Attempts to convert a naive datetime to an aware datetime."""
@@ -34,10 +37,12 @@ def guess_timezone(dt):
 
     return dt
 
+
 def remove_trailing_slash(host):
     if host.endswith('/'):
-         return host[:-1]
+        return host[:-1]
     return host
+
 
 def clean(item):
     if isinstance(item, Decimal):
@@ -52,8 +57,10 @@ def clean(item):
     else:
         return _coerce_unicode(item)
 
+
 def _clean_list(list_):
     return [clean(item) for item in list_]
+
 
 def _clean_dict(dict_):
     data = {}
@@ -68,6 +75,7 @@ def _clean_dict(dict_):
             )
     return data
 
+
 def _coerce_unicode(cmplx):
     try:
         item = cmplx.decode("utf-8", "strict")
@@ -76,6 +84,4 @@ def _coerce_unicode(cmplx):
         item.decode("utf-8", "strict")
         log.warning('Error decoding: %s', item)
         return None
-    except:
-        raise
     return item

--- a/simulator.py
+++ b/simulator.py
@@ -7,11 +7,13 @@ __name__ = 'simulator.py'
 __version__ = '0.0.1'
 __description__ = 'scripting simulator'
 
+
 def json_hash(str):
-  if str:
-    return json.loads(str)
+    if str:
+        return json.loads(str)
 
 # analytics -method=<method> -segment-write-key=<segmentWriteKey> [options]
+
 
 parser = argparse.ArgumentParser(description='send a segment message')
 
@@ -19,45 +21,58 @@ parser.add_argument('--writeKey', help='the Segment writeKey')
 parser.add_argument('--type', help='The Segment message type')
 
 parser.add_argument('--userId', help='the user id to send the event as')
-parser.add_argument('--anonymousId', help='the anonymous user id to send the event as')
-parser.add_argument('--context', help='additional context for the event (JSON-encoded)')
+parser.add_argument(
+    '--anonymousId', help='the anonymous user id to send the event as')
+parser.add_argument(
+    '--context', help='additional context for the event (JSON-encoded)')
 
 parser.add_argument('--event', help='the event name to send with the event')
-parser.add_argument('--properties', help='the event properties to send (JSON-encoded)')
+parser.add_argument(
+    '--properties', help='the event properties to send (JSON-encoded)')
 
-parser.add_argument('--name', help='name of the screen or page to send with the message')
+parser.add_argument(
+    '--name', help='name of the screen or page to send with the message')
 
-parser.add_argument('--traits', help='the identify/group traits to send (JSON-encoded)')
+parser.add_argument(
+    '--traits', help='the identify/group traits to send (JSON-encoded)')
 
 parser.add_argument('--groupId', help='the group id')
 
 options = parser.parse_args()
 
+
 def failed(status, msg):
     raise Exception(msg)
 
+
 def track():
-    analytics.track(options.userId, options.event, anonymous_id = options.anonymousId,
-            properties = json_hash(options.properties), context = json_hash(options.context))
+    analytics.track(options.userId, options.event, anonymous_id=options.anonymousId,
+                    properties=json_hash(options.properties), context=json_hash(options.context))
+
 
 def page():
-    analytics.page(options.userId, name = options.name, anonymous_id = options.anonymousId,
-            properties = json_hash(options.properties), context = json_hash(options.context))
+    analytics.page(options.userId, name=options.name, anonymous_id=options.anonymousId,
+                   properties=json_hash(options.properties), context=json_hash(options.context))
+
 
 def screen():
-    analytics.screen(options.userId, name = options.name, anonymous_id = options.anonymousId,
-            properties = json_hash(options.properties), context = json_hash(options.context))
+    analytics.screen(options.userId, name=options.name, anonymous_id=options.anonymousId,
+                     properties=json_hash(options.properties), context=json_hash(options.context))
+
 
 def identify():
-    analytics.identify(options.userId, anonymous_id = options.anonymousId,
-            traits = json_hash(options.traits), context = json_hash(options.context))
+    analytics.identify(options.userId, anonymous_id=options.anonymousId,
+                       traits=json_hash(options.traits), context=json_hash(options.context))
+
 
 def group():
     analytics.group(options.userId, options.groupId, json_hash(options.traits),
-            json_hash(options.context), anonymous_id = options.anonymousId)
+                    json_hash(options.context), anonymous_id=options.anonymousId)
+
 
 def unknown():
     print()
+
 
 analytics.write_key = options.writeKey
 analytics.on_error = failed


### PR DESCRIPTION
This pull request should fix all linting errors previously found by pycodestyle.
Pycodestyle has been replaced by flake8 which should cover a bit more regarding code quality.
Line length has been set to 79 (PEP8's recommended line length).
CircleCI no longer stores pycodestyle.out but flake8.out

Most changes are styling changes to comply with flake8's warnings.
`.circleci/config.yml` and  `Makefile` have the most meaningful changes regarding the replacement of pycodestyle with flake8.