### PR TITLE
Deprecate support for Python 3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,25 +56,7 @@ jobs:
             git diff origin/master..HEAD analytics | flake8 --diff --max-complexity=10 analytics
       - run: make test
       - run: make e2e_test
-
-  test_34:
-    docker:
-      - image: circleci/python:3.4
-    steps:
-      - checkout
-      - run: pip install --user .[test]
-
-      # The circleci/python:3.4 image doesn't set PATH correctly, so we need to
-      # install these by hand with sudo
-      - run: sudo pip install coverage pylint==1.9.3 flake8 mock==3.0.5
-
-      - run:
-          name: Linting with Flake8
-          command: |
-            git diff origin/master..HEAD analytics | flake8 --diff --max-complexity=10 analytics
-      - run: make test
-      - run: make e2e_test
-
+  
   test_35:
     <<: *test
     docker:
@@ -113,9 +95,6 @@ workflows:
       - test_27:
           filters:
             <<: *taggedReleasesFilter
-      - test_34:
-          filters:
-            <<: *taggedReleasesFilter
       - test_35:
           filters:
             <<: *taggedReleasesFilter
@@ -132,7 +111,6 @@ workflows:
           requires:
             - build
             - test_27
-            - test_34
             - test_35
             - test_36
             - test_37
@@ -162,6 +140,5 @@ workflows:
                 - scheduled_e2e_testing
     jobs:
       - test_27
-      - test_34
       - test_35
       - test_36

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
-1.3.0 / 2018-10-10
+1.3.0-beta1 / 2019-04-27
+==================
+ 
+  * Add `sync_mode` option ([#147](https://github.com/segmentio/analytics-python/pull/147))
+
+1.3.0-beta0 / 2018-10-10
 ==================
 
   * Add User-Agent header to messages
@@ -12,7 +17,6 @@
   * Drop messages greater than 32kb
   * Allow user-defined upload size
   * Support custom messageId
-  * Add `sync_mode` option ([#147](https://github.com/segmentio/analytics-python/pull/147))
 
 1.2.9 / 2017-11-28
 ==================


### PR DESCRIPTION
Python 3.4 has no longer received official support since March 2019.

Changelog is also updated to reflect beta versioning.