### PR TITLE
Semver compatible dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ Documentation and more details at https://github.com/segmentio/analytics-python
 '''
 
 install_requires = [
-    "requests>=2.7,<3.0",
-    "six>=1.5",
-    "monotonic>=1.5",
+    "requests~=2.7",
+    "six~=1.5",
+    "monotonic~=1.5",
     "backoff~=1.10",
-    "python-dateutil>2.1"
+    "python-dateutil~=2.2"
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     "requests>=2.7,<3.0",
     "six>=1.5",
     "monotonic>=1.5",
-    "backoff==1.10.0",
+    "backoff~=1.10",
     "python-dateutil>2.1"
 ]
 


### PR DESCRIPTION
* Unpin backoff dependency (semver-compatibly) (917ae81)

    Closes https://github.com/segmentio/analytics-python/issues/188

    This means users will be able to update the backoff dependency without
    conflicting with the segment analytics library's requirements.


* Use semver-compatibility operator everywhere (12fa761)

    This will prevent the library from accidentally installing a possibly
    backwards-incompatible version.

    For `requests`, the check is equivalent to >=2.7,<3.0
    For `six` and `monotonic` it adds a constraint to prevent major version bumps
    For `python-dateutil`, the check isn't theoritcally equivalent,
    but in practice the only release after 2.1 is 2.2 so it should work the same.