### PR TITLE
Support Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
 
   publish:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.9
     steps:
       - checkout
       - run: sudo pip install twine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,3 +131,6 @@ workflows:
       - test_27
       - test_35
       - test_36
+      - test_37
+      - test_38
+      - test_39

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,11 @@ jobs:
     docker:
       - image: circleci/python:3.8
 
+  test_39:
+    <<: *test
+    docker:
+      - image: circleci/python:3.9
+
   publish:
     docker:
       - image: circleci/python:3.6
@@ -90,6 +95,9 @@ workflows:
       - test_38:
           filters:
             <<: *taggedReleasesFilter
+      - test_39:
+          filters:
+            <<: *taggedReleasesFilter
       - publish:
           requires:
             - build
@@ -98,6 +106,7 @@ workflows:
             - test_36
             - test_37
             - test_38
+            - test_39
           filters:
             <<: *taggedReleasesFilter
             branches:

--- a/setup.py
+++ b/setup.py
@@ -67,5 +67,6 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )


### PR DESCRIPTION
Closes #190 

* Add CI tests for Python 3.9 (153df10)

* Add latest Python 3 version to e2e test (f0b0c03)

    Possibly a bad idea -- not sure why they're excluded in the first place 🤔 

* Add Python 3.9 to project's Trove classifiers (f71db5f)

* Use latest Python image for publish job (2085498)

    Python 3.6 end-of-support is in December 2021, let's upgrade ahead of time!