### PR TITLE
docs: fix simple typo, paramater -> parameter

### DIFF
--- a/segment/analytics/test/consumer.py
+++ b/segment/analytics/test/consumer.py
@@ -118,7 +118,7 @@ class TestConsumer(unittest.TestCase):
                 'userId': 'userId'
             }
             # request() should succeed if the number of exceptions raised is
-            # less than the retries paramater.
+            # less than the retries parameter.
             if exception_count <= consumer.retries:
                 consumer.request([track])
             else:


### PR DESCRIPTION
There is a small typo in segment/analytics/test/consumer.py.

Should read `parameter` rather than `paramater`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md