### PR TITLE
Raise exception on large message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build
 .eggs
 *.bat
 .vscode/
+.idea/
+.python-version

--- a/segment/analytics/client.py
+++ b/segment/analytics/client.py
@@ -276,7 +276,7 @@ class Client(object):
         # Check message size.
         msg_size = len(json.dumps(msg, cls=DatetimeSerializer).encode())
         if msg_size > MAX_MSG_SIZE:
-            raise RuntimeError('Message exceeds 32kb limit. (%s)', str(msg))
+            raise RuntimeError('Message exceeds %skb limit. (%s)', str(int(MAX_MSG_SIZE / 1024)), str(msg))
 
         # if send is False, return msg as if it was successfully queued
         if not self.send:


### PR DESCRIPTION
Raise exception (`RuntimeError`) when the message size exceeds 32 kB. This way callers can programmatically detect if the message size was over the 32 kb limit. Before this PR, the library logs an error to console and silently drops the message.

Minor changes:
- Remove duplicate `max_entries=10` line
- Add two lines to `.gitignore` file (PyCharm directory and pyenv file)

I work for Instacart. My work email address is **david.pal@instacart.com**