### PR TITLE
Remove python 2 support

### DIFF
--- a/.buildscripts/e2e.sh
+++ b/.buildscripts/e2e.sh
@@ -12,5 +12,3 @@ else
     ./tester_linux_amd64 -segment-write-key="${SEGMENT_WRITE_KEY}" -webhook-auth-username="${WEBHOOK_AUTH_USERNAME}" -webhook-bucket="${WEBHOOK_BUCKET}" -path='./e2e_test.sh'
     echo "End to end tests completed!"
 fi
-
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - checkout
       - attach_workspace: { at: . }
-      - run: pip3 install dephell 
-      - run: pip3 install --user appdirs   
+      - run: pip3 install dephell
+      - run: pip3 install --user appdirs
       - run: dephell deps convert --from=setup.py --to=requirements.txt
       - run: pip3 install --user -r requirements.txt
       - run: curl -sL https://raw.githubusercontent.com/segmentio/snyk_helpers/master/initialization/snyk.sh | sh
@@ -114,7 +114,7 @@ workflows:
                 - master
                 - scheduled_e2e_testing
     jobs:
-      - test_36      
+      - test_36
       - test_37
       - test_38
       - test_39

--- a/.pylintrc
+++ b/.pylintrc
@@ -306,7 +306,7 @@ init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins,io,builtins
+redefining-builtins-modules=past.builtins,future.builtins,io,builtins
 
 
 [FORMAT]

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 2.2.0 / 2022-03-07
+- Remove Python 2 support
+- Remove six package
+
 # 2.1.0 / 2022-03-04
 
 - Raise exception on large message

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+install_dev:
+	pip install --edit .[dev]
+
 test:
 	pylint --rcfile=.pylintrc --reports=y --exit-zero analytics | tee pylint.out
 	flake8 --max-complexity=10 --statistics analytics > flake8.out || true

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-install_dev:
-	pip install --edit .[dev]
+install:
+	pip install --edit .[test]
 
 test:
 	pylint --rcfile=.pylintrc --reports=y --exit-zero analytics | tee pylint.out

--- a/analytics/consumer.py
+++ b/analytics/consumer.py
@@ -7,10 +7,7 @@ import backoff
 
 from analytics.request import post, APIError, DatetimeSerializer
 
-try:
-    from queue import Empty
-except ImportError:
-    from Queue import Empty
+from queue import Empty
 
 MAX_MSG_SIZE = 32 << 10
 

--- a/analytics/test/client.py
+++ b/analytics/test/client.py
@@ -1,7 +1,6 @@
 from datetime import date, datetime
 import unittest
 import time
-import six
 import mock
 
 from analytics.version import VERSION

--- a/segment/analytics/client.py
+++ b/segment/analytics/client.py
@@ -6,20 +6,15 @@ import atexit
 import json
 
 from dateutil.tz import tzutc
-from six import string_types
 
 from segment.analytics.utils import guess_timezone, clean
 from segment.analytics.consumer import Consumer, MAX_MSG_SIZE
 from segment.analytics.request import post, DatetimeSerializer
 from segment.analytics.version import VERSION
 
-try:
-    import queue
-except ImportError:
-    import Queue as queue
+import queue
 
-
-ID_TYPES = (numbers.Number, string_types)
+ID_TYPES = (numbers.Number, str)
 
 
 class Client(object):

--- a/segment/analytics/consumer.py
+++ b/segment/analytics/consumer.py
@@ -6,10 +6,7 @@ import json
 
 from segment.analytics.request import post, APIError, DatetimeSerializer
 
-try:
-    from queue import Empty
-except ImportError:
-    from Queue import Empty
+from queue import Empty
 
 MAX_MSG_SIZE = 32 << 10
 

--- a/segment/analytics/test/client.py
+++ b/segment/analytics/test/client.py
@@ -1,7 +1,6 @@
 from datetime import date, datetime
 import unittest
 import time
-import six
 import mock
 
 from analytics.version import VERSION
@@ -286,7 +285,7 @@ class TestClient(unittest.TestCase):
         self.assertFalse(self.failed)
 
     def test_unicode(self):
-        Client(six.u('unicode_key'))
+        Client('unicode_key')
 
     def test_numeric_user_id(self):
         self.client.track(1234, 'python event')

--- a/segment/analytics/test/utils.py
+++ b/segment/analytics/test/utils.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 import unittest
 
 from dateutil.tz import tzutc
-import six
 
 from analytics import utils
 
@@ -25,7 +24,7 @@ class TestUtils(unittest.TestCase):
     def test_clean(self):
         simple = {
             'decimal': Decimal('0.142857'),
-            'unicode': six.u('woo'),
+            'unicode': 'woo',
             'date': datetime.now(),
             'long': 200000000,
             'integer': 1,
@@ -58,11 +57,7 @@ class TestUtils(unittest.TestCase):
 
     @classmethod
     def test_bytes(cls):
-        if six.PY3:
-            item = bytes(10)
-        else:
-            item = bytearray(10)
-
+        item = bytes(10)
         utils.clean(item)
 
     def test_clean_fn(self):

--- a/segment/analytics/utils.py
+++ b/segment/analytics/utils.py
@@ -6,8 +6,6 @@ from decimal import Decimal
 from datetime import date, datetime
 from dateutil.tz import tzlocal, tzutc
 
-import six
-
 log = logging.getLogger('segment')
 
 
@@ -48,7 +46,7 @@ def remove_trailing_slash(host):
 def clean(item):
     if isinstance(item, Decimal):
         return float(item)
-    elif isinstance(item, (six.string_types, bool, numbers.Number, datetime,
+    elif isinstance(item, (str, bool, numbers.Number, datetime,
                            date, type(None))):
         return item
     elif isinstance(item, (set, list, tuple)):
@@ -67,7 +65,7 @@ def _clean_list(list_):
 
 def _clean_dict(dict_):
     data = {}
-    for k, v in six.iteritems(dict_):
+    for k, v in dict_.items():
         try:
             data[k] = clean(v)
         except TypeError:

--- a/segment/analytics/version.py
+++ b/segment/analytics/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.1.0'
+VERSION = '2.2.0'

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     maintainer_email='friends@segment.com',
     test_suite='analytics.test.all',
     packages=['segment.analytics', 'analytics.test'],
+    python_requires='>=3.6.0',
     license='MIT License',
     install_requires=install_requires,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ Documentation and more details at https://github.com/segmentio/analytics-python
 
 install_requires = [
     "requests~=2.7",
-    "six~=1.5",
     "monotonic~=1.5",
     "backoff~=1.10",
     "python-dateutil~=2.2"


### PR DESCRIPTION
This PR removes the legacy support for Python 2. 

The support for Python was dropped in version 2.0.0 of the package. The end-to-end tests run using Python 3.6+ only.

Details:
- Add `python_requires='>=3.6.0'` to `setup.py`
- Remove dependency on `six` package
- Remove all imports of `six` package
- Remove `try import` blocks for Python 2 version of queue
- Replace `six.string_types` with `str`
- Remove uses of `six.u()` and `six.PY3`
- Replace use of `six.iteritems(...)` with `.items()`.
- Remove trailing spaces, trailing empty lines from text files; add missing `\n` at the end of text files
- Add `make install` target
