### PR TITLE
Fix empty catch

### DIFF
--- a/segment/analytics/consumer.py
+++ b/segment/analytics/consumer.py
@@ -102,10 +102,10 @@ class Consumer(Thread):
                     self.log.debug(
                         'hit batch size limit (size: %d)', total_size)
                     break
-            except Exception as e:
-                self.log.error('Exception: %s', e)
             except Empty:
                 break
+            except Exception as e:
+                self.log.exception('Exception: %s', e)
 
         return items
 


### PR DESCRIPTION
This was spamming us with `Exception:` and never catching the `Empty` exception properly. I've fixed both issues by moving the `Empty` catch block above the broad catch, and using `log.exception` properly so that the stack trace is included in the error message.

I'd strongly suggest all `logger.<level>` calls in the project that are inside exception handlers are either converted to `logger.exception` or `logger.<level>("message", exec_info=True)`. Otherwise you will find yourself a logger emitting a potentially useless message.

Just logging the string representation of the message loses you the stack trace. I've had very stressful 2am outages trying to find errors that were a result of this anti-pattern in other projects just fyi.