### PR TITLE
Loosen the backoff dependency version pin.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ Documentation and more details at https://github.com/segmentio/analytics-python
 install_requires = [
     "requests~=2.7",
     "monotonic~=1.5",
-    "backoff~=1.10",
+    "backoff>=1.10,<3.0",
     "python-dateutil~=2.2"
 ]
 


### PR DESCRIPTION
In order to keep our dependencies up-to-date we need to loosen a little bit the backoff dependency of this lib so that we can upgrade to `gql 3.4.0`