### PR TITLE
Update from monotonic to time module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,6 @@ MarkupSafe==2.1.3
 mccabe==0.6.1
 mistune==0.8.4
 mock==2.0.0
-monotonic==1.6
 multidict==5.1.0
 packaging==21.0
 pbr==5.11.1

--- a/segment/analytics/consumer.py
+++ b/segment/analytics/consumer.py
@@ -1,6 +1,6 @@
 import logging
+import time
 from threading import Thread
-import monotonic
 import backoff
 import json
 
@@ -88,11 +88,11 @@ class Consumer(Thread):
         queue = self.queue
         items = []
 
-        start_time = monotonic.monotonic()
+        start_time = time.monotonic()
         total_size = 0
 
         while len(items) < self.upload_size:
-            elapsed = monotonic.monotonic() - start_time
+            elapsed = time.monotonic() - start_time
             if elapsed >= self.upload_interval:
                 break
             try:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ Documentation and more details at https://github.com/segmentio/analytics-python
 
 install_requires = [
     "requests~=2.7",
-    "monotonic~=1.5",
     "backoff~=2.1",
     "python-dateutil~=2.2"
 ]


### PR DESCRIPTION
Since 3.3 there's a `time.monotonic()` function which implements this behavior, so the `monotonic` dependency (which is no longer maintained) can be removed.

(Hope the PR is welcome! I figured this tweak was small enough I'd just open this rather than file an issue first.)