### PR TITLE
fix: widen PyJWT version constraint to allow 2.11+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     "requests~=2.7",
     "backoff~=2.1",
     "python-dateutil~=2.2",
-    "PyJWT~=2.10.1"
+    "PyJWT~=2.10"
 ]
 
 tests_require = [


### PR DESCRIPTION
## Summary
- Changes `PyJWT~=2.10.1` (`>=2.10.1, <2.11`) to `PyJWT~=2.10` (`>=2.10, <3`) in `setup.py`
- Matches the version constraint pattern used by the other dependencies (`requests~=2.7`, `backoff~=2.1`, `python-dateutil~=2.2`)
- SDK only uses `jwt.encode()` with RS256, which is a stable API surface

Fixes #522

## Test plan
- [x] Verified `pip install` resolves to PyJWT 2.11.0 with the new constraint
- [x] All 72 non-OAuth tests pass (7 OAuth tests fail on `main` too — missing `cryptography` package in test env, pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)