### PR TITLE
Update e2e-tests CI: skip fork PRs, accept test ref input

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,10 +13,17 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      e2e_tests_ref:
+        description: 'Branch or ref of sdk-e2e-tests to use'
+        required: false
+        default: 'main'
 
 jobs:
   e2e-tests:
+    # Skip on fork PRs where repo secrets aren't available
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
 
     steps:
@@ -29,6 +36,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: segmentio/sdk-e2e-tests
+          ref: ${{ inputs.e2e_tests_ref || 'main' }}
           token: ${{ secrets.E2E_TESTS_TOKEN }}
           path: sdk-e2e-tests
 


### PR DESCRIPTION
- Skip e2e tests on fork PRs (secrets unavailable)
- Accept `e2e_tests_ref` workflow input for cross-repo test validation