### PR TITLE
fix: upgrade pyjwt to 2.12.1 to address CVE-2026-32597

### DIFF
--- a/e2e-cli/requirements.txt
+++ b/e2e-cli/requirements.txt
@@ -2,5 +2,5 @@ click==8.1.8
 python-dotenv==1.0.1
 python-dateutil==2.8.2
 requests==2.32.3
-PyJWT==2.10.1
+PyJWT==2.12.1
 backoff==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ cryptography==44.0.0
 flake8==7.1.1
 mock==2.0.0
 pylint==3.3.3
-PyJWT==2.10.1
+PyJWT==2.12.1
 python-dateutil==2.8.2
 requests==2.32.3

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     "requests~=2.7",
     "backoff~=2.1",
     "python-dateutil~=2.2",
-    "PyJWT~=2.10"
+    "PyJWT~=2.12"
 ]
 
 tests_require = [


### PR DESCRIPTION
This updates the pyjwt dependency from 2.10.1 to 2.12.1 to fix the security vulnerability described in issue #526.